### PR TITLE
ZVRK-30: Broadcast events

### DIFF
--- a/app/Broadcasting/GameChatChannel.php
+++ b/app/Broadcasting/GameChatChannel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\GameSession;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+final class GameChatChannel
+{
+    use AuthorizesRequests;
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function join(User $user, GameSession $gameSession): bool
+    {
+        $this->authorize('join', $gameSession);
+
+        return true;
+    }
+}

--- a/app/Broadcasting/GameSessionChannel.php
+++ b/app/Broadcasting/GameSessionChannel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\GameSession;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+final class GameSessionChannel
+{
+    use AuthorizesRequests;
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function join(User $user, GameSession $gameSession): array|false
+    {
+        $this->authorize('join', $gameSession);
+
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+        ];
+    }
+}

--- a/app/Broadcasting/LobbyChannel.php
+++ b/app/Broadcasting/LobbyChannel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+
+final class LobbyChannel
+{
+    public function join(User $user, string $gameSlug): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+        ];
+    }
+}

--- a/app/Broadcasting/UserChannel.php
+++ b/app/Broadcasting/UserChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+
+final class UserChannel
+{
+    public function join(User $user, string $id): bool
+    {
+        return $user->id === $id;
+    }
+}

--- a/app/Events/ChatMessageSent.php
+++ b/app/Events/ChatMessageSent.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ChatMessageSent implements ShouldBroadcast
+final class ChatMessageSent implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -20,11 +20,9 @@ class ChatMessageSent implements ShouldBroadcast
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PrivateChannel
     {
-        return [
-            new PrivateChannel("game.{$this->sessionId}.chat"),
-        ];
+        return new PrivateChannel("game.{$this->sessionId}.chat");
     }
 
     public function broadcastAs(): string

--- a/app/Events/ChatMessageSent.php
+++ b/app/Events/ChatMessageSent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ChatMessageSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public string $message,
+        public string $senderId,
+        public string $senderName,
+    ) {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return [
+            new PrivateChannel("game.{$this->sessionId}.chat"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'chat.message.sent';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'sessionId' => $this->sessionId,
+            'message' => $this->message,
+            'sender' => [
+                'id' => $this->senderId,
+                'name' => $this->senderName,
+            ],
+        ];
+    }
+}

--- a/app/Events/GameEnded.php
+++ b/app/Events/GameEnded.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class GameEnded implements ShouldBroadcast
+final class GameEnded implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -20,11 +20,9 @@ class GameEnded implements ShouldBroadcast
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return [
-            new PresenceChannel("game.{$this->sessionId}"),
-        ];
+        return new PresenceChannel("game.{$this->sessionId}");
     }
 
     public function broadcastAs(): string

--- a/app/Events/GameEnded.php
+++ b/app/Events/GameEnded.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class GameEnded implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public ?string $winner,
+        public bool $draw,
+        public array $board,
+    ) {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return [
+            new PresenceChannel("game.{$this->sessionId}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'game.ended';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'sessionId' => $this->sessionId,
+            'winner' => $this->winner,
+            'draw' => $this->draw,
+            'board' => $this->board,
+        ];
+    }
+}

--- a/app/Events/GameStarted.php
+++ b/app/Events/GameStarted.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class GameStarted implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public array $board,
+        public string $startingPlayerId,
+    ) {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return [
+            new PresenceChannel("game.{$this->sessionId}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'game.started';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'sessionId' => $this->sessionId,
+            'board' => $this->board,
+            'startingPlayerId' => $this->startingPlayerId,
+        ];
+    }
+}

--- a/app/Events/GameStarted.php
+++ b/app/Events/GameStarted.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class GameStarted implements ShouldBroadcast
+final readonly class GameStarted implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -19,11 +19,9 @@ class GameStarted implements ShouldBroadcast
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return [
-            new PresenceChannel("game.{$this->sessionId}"),
-        ];
+        return new PresenceChannel("game.{$this->sessionId}");
     }
 
     public function broadcastAs(): string

--- a/app/Events/MoveMade.php
+++ b/app/Events/MoveMade.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MoveMade implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $sessionId,
+        public string $playerId,
+        public int $row,
+        public int $column,
+        public array $board,
+        public ?string $nextPlayerId = null,
+        public ?string $winner = null,
+        public bool $draw = false,
+    ) {
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PresenceChannel("game.{$this->sessionId}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'move.made';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'sessionId' => $this->sessionId,
+            'playerId' => $this->playerId,
+            'row' => $this->row,
+            'column' => $this->column,
+            'board' => $this->board,
+            'nextPlayerId' => $this->nextPlayerId,
+            'winner' => $this->winner,
+            'draw' => $this->draw,
+        ];
+    }
+}

--- a/app/Events/MoveMade.php
+++ b/app/Events/MoveMade.php
@@ -24,7 +24,7 @@ class MoveMade implements ShouldBroadcast
     ) {
     }
 
-    public function broadcastOn(): array
+    public function broadcastOn(): Channel
     {
         return [
             new PresenceChannel("game.{$this->sessionId}"),

--- a/app/Events/MoveMade.php
+++ b/app/Events/MoveMade.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class MoveMade implements ShouldBroadcast
+final class MoveMade implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -19,16 +19,12 @@ class MoveMade implements ShouldBroadcast
         public int $column,
         public array $board,
         public ?string $nextPlayerId = null,
-        public ?string $winner = null,
-        public bool $draw = false,
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return [
-            new PresenceChannel("game.{$this->sessionId}"),
-        ];
+        return new PresenceChannel("game.{$this->sessionId}");
     }
 
     public function broadcastAs(): string
@@ -45,8 +41,6 @@ class MoveMade implements ShouldBroadcast
             'column' => $this->column,
             'board' => $this->board,
             'nextPlayerId' => $this->nextPlayerId,
-            'winner' => $this->winner,
-            'draw' => $this->draw,
         ];
     }
 }

--- a/app/Events/PlayerJoinedLobby.php
+++ b/app/Events/PlayerJoinedLobby.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class PlayerJoinedLobby implements ShouldBroadcast
+final class PlayerJoinedLobby implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
@@ -19,11 +19,9 @@ class PlayerJoinedLobby implements ShouldBroadcast
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return [
-            new PresenceChannel("lobby.{$this->gameSlug}"),
-        ];
+        return new PresenceChannel("lobby.{$this->gameSlug}");
     }
 
     public function broadcastAs(): string

--- a/app/Events/PlayerJoinedLobby.php
+++ b/app/Events/PlayerJoinedLobby.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PlayerJoinedLobby implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $gameSlug,
+        public string $playerId,
+        public string $playerName,
+    ) {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return [
+            new PresenceChannel("lobby.{$this->gameSlug}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'player.joined.lobby';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'gameSlug' => $this->gameSlug,
+            'player' => [
+                'id' => $this->playerId,
+                'name' => $this->playerName,
+            ],
+        ];
+    }
+}

--- a/app/Events/PlayerLeftLobby.php
+++ b/app/Events/PlayerLeftLobby.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PlayerLeftLobby implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public string $gameSlug,
+        public string $playerId,
+    ) {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return [
+            new PresenceChannel("lobby.{$this->gameSlug}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'player.left.lobby';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'gameSlug' => $this->gameSlug,
+            'player' => [
+                'id' => $this->playerId,
+                'name' => $this->playerName,
+            ],
+        ];
+    }
+}

--- a/app/Events/PlayerLeftLobby.php
+++ b/app/Events/PlayerLeftLobby.php
@@ -8,21 +8,20 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class PlayerLeftLobby implements ShouldBroadcast
+final class PlayerLeftLobby implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
         public string $gameSlug,
         public string $playerId,
+        public string $playerName,
     ) {
     }
 
-    public function broadcastOn(): Channel
+    public function broadcastOn(): PresenceChannel
     {
-        return [
-            new PresenceChannel("lobby.{$this->gameSlug}"),
-        ];
+        return new PresenceChannel("lobby.{$this->gameSlug}");
     }
 
     public function broadcastAs(): string

--- a/app/Games/TicTacToeEngine.php
+++ b/app/Games/TicTacToeEngine.php
@@ -5,9 +5,9 @@ namespace App\Games;
 use App\Contracts\GameContract;
 use App\Data\GameResult;
 use App\Data\GameState;
-use App\Data\TicTacToeState;
-use App\Data\TicTacToeMoveData;
 use App\Data\MoveData;
+use App\Data\TicTacToeMoveData;
+use App\Data\TicTacToeState;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
@@ -40,7 +40,7 @@ class TicTacToeEngine implements GameContract
         if (! $moveData instanceof TicTacToeMoveData) {
             throw new InvalidArgumentException('TicTacToeEngine expects TicTacToeMoveData.');
         }
-        
+
         // rejects: out-of-bounds, occupied cells, wrong player's turn
         $row = $moveData->row;
         $col = $moveData->col;

--- a/app/Models/GameSession.php
+++ b/app/Models/GameSession.php
@@ -80,7 +80,7 @@ final class GameSession extends Model
         return $this->belongsTo(User::class, 'winner_user_id');
     }
 
-    public function gamePlayers(): HasMany
+    public function players(): HasMany
     {
         return $this->hasMany(GamePlayer::class);
     }

--- a/app/Policies/GameSessionPolicy.php
+++ b/app/Policies/GameSessionPolicy.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\GameSession;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+final readonly class GameSessionPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, GameSession $gameSession): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, GameSession $gameSession): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, GameSession $gameSession): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, GameSession $gameSession): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, GameSession $gameSession): bool
+    {
+        return false;
+    }
+
+    public function join(User $user, GameSession $gameSession): bool
+    {
+        $isHost = $gameSession->host_user_id === $user->id;
+        $isPlayer = $gameSession->players()->where('user_id', $user->id)->exists();
+
+        if (! $isHost && ! $isPlayer) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,7 +1,19 @@
 <?php
 
 use Illuminate\Support\Facades\Broadcast;
+use App\Models\User;
+use App\Models\GameSession;
 
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
+});
+
+Broadcast::channel('game.{sessionId}', function (User $user, GameSession $session) : array|bool {
+    $isHost = $session->host_user_id === $user->id;
+    $isPlayer = $session->players()->where('user_id', $user->id)->exists();
+    if (!$isHost && !$isPlayer) return false;
+    return [
+        'id' => $user->id,
+        'name' => $user->name,
+    ];
 });

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,33 +1,13 @@
 <?php
 
+use App\Broadcasting\GameChatChannel;
+use App\Broadcasting\GameSessionChannel;
+use App\Broadcasting\LobbyChannel;
+use App\Broadcasting\UserChannel;
 use Illuminate\Support\Facades\Broadcast;
-use App\Models\User;
-use App\Models\GameSession;
-use App\Models\Game;
 
-Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
-    return (int) $user->id === (int) $id;
-});
+Broadcast::channel('App.Models.User.{id}', UserChannel::class);
 
-Broadcast::channel('game.{sessionId}', function (User $user, GameSession $session) : array|bool {
-    $isHost = $session->host_user_id === $user->id;
-    $isPlayer = $session->players()->where('user_id', $user->id)->exists();
-    if (!$isHost && !$isPlayer) return false;
-    return [
-        'id' => $user->id,
-        'name' => $user->name,
-    ];
-});
-
-Broadcast::channel('lobby.{gameSlug}', function (User $user, string $gameSlug) : array|bool {
-    return [
-        'id' => $user->id,
-        'name' => $user->name,
-    ];
-});
-
-Broadcast::channel('game.{sessionId}.chat', function (User $user, GameSession $session) : bool {
-    $isHost = $session->host_user_id === $user->id;
-    $isPlayer = $session->players()->where('user_id', $user->id)->exists();
-    return $isHost || $isPlayer;
-});
+Broadcast::channel('game.{sessionId}', GameSessionChannel::class);
+Broadcast::channel('lobby.{gameSlug}', LobbyChannel::class);
+Broadcast::channel('game.{sessionId}.chat', GameChatChannel::class);

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Broadcast;
 use App\Models\User;
 use App\Models\GameSession;
+use App\Models\Game;
 
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
@@ -16,4 +17,17 @@ Broadcast::channel('game.{sessionId}', function (User $user, GameSession $sessio
         'id' => $user->id,
         'name' => $user->name,
     ];
+});
+
+Broadcast::channel('lobby.{gameSlug}', function (User $user, string $gameSlug) : array|bool {
+    return [
+        'id' => $user->id,
+        'name' => $user->name,
+    ];
+});
+
+Broadcast::channel('game.{sessionId}.chat', function (User $user, GameSession $session) : bool {
+    $isHost = $session->host_user_id === $user->id;
+    $isPlayer = $session->players()->where('user_id', $user->id)->exists();
+    return $isHost || $isPlayer;
 });

--- a/tests/Unit/Events/ChatMessageSentTest.php
+++ b/tests/Unit/Events/ChatMessageSentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\ChatMessageSent;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Tests\TestCase;
+
+class ChatMessageSentTest extends TestCase
+{
+    public function test_it_implements_should_broadcast(): void
+    {
+        $event = new ChatMessageSent(
+            sessionId: 'session-1',
+            message: 'Hello!',
+            senderId: 'player-1',
+            senderName: 'Alice',
+        );
+
+        $this->assertInstanceOf(ShouldBroadcast::class, $event);
+    }
+
+    public function test_it_broadcasts_on_game_chat_private_channel(): void
+    {
+        $event = new ChatMessageSent(
+            sessionId: 'session-1',
+            message: 'Hello!',
+            senderId: 'player-1',
+            senderName: 'Alice',
+        );
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(PrivateChannel::class, $channel);
+        $this->assertSame('private-game.session-1.chat', $channel->name);
+    }
+
+    public function test_it_broadcasts_as_chat_message_sent(): void
+    {
+        $event = new ChatMessageSent(
+            sessionId: 'session-1',
+            message: 'Hello!',
+            senderId: 'player-1',
+            senderName: 'Alice',
+        );
+
+        $this->assertSame('chat.message.sent', $event->broadcastAs());
+    }
+
+    public function test_it_broadcasts_correct_payload(): void
+    {
+        $event = new ChatMessageSent(
+            sessionId: 'session-1',
+            message: 'Hello!',
+            senderId: 'player-1',
+            senderName: 'Alice',
+        );
+
+        $this->assertSame([
+            'sessionId' => 'session-1',
+            'message' => 'Hello!',
+            'sender' => [
+                'id' => 'player-1',
+                'name' => 'Alice',
+            ],
+        ], $event->broadcastWith());
+    }
+}

--- a/tests/Unit/Events/GameEndedTest.php
+++ b/tests/Unit/Events/GameEndedTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\GameEnded;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Tests\TestCase;
+
+class GameEndedTest extends TestCase
+{
+    public function test_it_implements_should_broadcast(): void
+    {
+        $event = new GameEnded(
+            sessionId: 'session-1',
+            winner: 'player-1',
+            draw: false,
+            board: [[1, 1, 1], [2, 2, 0], [0, 0, 0]],
+        );
+
+        $this->assertInstanceOf(ShouldBroadcast::class, $event);
+    }
+
+    public function test_it_broadcasts_on_game_presence_channel(): void
+    {
+        $event = new GameEnded(
+            sessionId: 'session-1',
+            winner: 'player-1',
+            draw: false,
+            board: [[1, 1, 1], [2, 2, 0], [0, 0, 0]],
+        );
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(PresenceChannel::class, $channel);
+        $this->assertSame('presence-game.session-1', $channel->name);
+    }
+
+    public function test_it_broadcasts_as_game_ended(): void
+    {
+        $event = new GameEnded(
+            sessionId: 'session-1',
+            winner: 'player-1',
+            draw: false,
+            board: [[1, 1, 1], [2, 2, 0], [0, 0, 0]],
+        );
+
+        $this->assertSame('game.ended', $event->broadcastAs());
+    }
+
+    public function test_it_broadcasts_correct_payload_with_winner(): void
+    {
+        $board = [[1, 1, 1], [2, 2, 0], [0, 0, 0]];
+
+        $event = new GameEnded(
+            sessionId: 'session-1',
+            winner: 'player-1',
+            draw: false,
+            board: $board,
+        );
+
+        $this->assertSame([
+            'sessionId' => 'session-1',
+            'winner' => 'player-1',
+            'draw' => false,
+            'board' => $board,
+        ], $event->broadcastWith());
+    }
+
+    public function test_it_broadcasts_correct_payload_on_draw(): void
+    {
+        $board = [[1, 2, 1], [1, 2, 2], [2, 1, 1]];
+
+        $event = new GameEnded(
+            sessionId: 'session-1',
+            winner: null,
+            draw: true,
+            board: $board,
+        );
+
+        $this->assertSame([
+            'sessionId' => 'session-1',
+            'winner' => null,
+            'draw' => true,
+            'board' => $board,
+        ], $event->broadcastWith());
+    }
+}

--- a/tests/Unit/Events/MoveMadeTest.php
+++ b/tests/Unit/Events/MoveMadeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\MoveMade;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Tests\TestCase;
+
+class MoveMadeTest extends TestCase
+{
+    public function test_it_implements_should_broadcast(): void
+    {
+        $event = new MoveMade(
+            sessionId: 'session-1',
+            playerId: 'player-1',
+            row: 0,
+            column: 1,
+            board: [[0, 1, 0], [0, 0, 0], [0, 0, 0]],
+            nextPlayerId: 'player-2',
+        );
+
+        $this->assertInstanceOf(ShouldBroadcast::class, $event);
+    }
+
+    public function test_it_broadcasts_on_game_presence_channel(): void
+    {
+        $event = new MoveMade(
+            sessionId: 'session-1',
+            playerId: 'player-1',
+            row: 0,
+            column: 1,
+            board: [[0, 1, 0], [0, 0, 0], [0, 0, 0]],
+            nextPlayerId: 'player-2',
+        );
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(PresenceChannel::class, $channel);
+        $this->assertSame('presence-game.session-1', $channel->name);
+    }
+
+    public function test_it_broadcasts_as_move_made(): void
+    {
+        $event = new MoveMade(
+            sessionId: 'session-1',
+            playerId: 'player-1',
+            row: 0,
+            column: 1,
+            board: [[0, 1, 0], [0, 0, 0], [0, 0, 0]],
+            nextPlayerId: 'player-2',
+        );
+
+        $this->assertSame('move.made', $event->broadcastAs());
+    }
+
+    public function test_it_broadcasts_correct_payload(): void
+    {
+        $board = [[0, 1, 0], [0, 0, 0], [0, 0, 0]];
+
+        $event = new MoveMade(
+            sessionId: 'session-1',
+            playerId: 'player-1',
+            row: 0,
+            column: 1,
+            board: $board,
+            nextPlayerId: 'player-2',
+        );
+
+        $this->assertSame([
+            'sessionId' => 'session-1',
+            'playerId' => 'player-1',
+            'row' => 0,
+            'column' => 1,
+            'board' => $board,
+            'nextPlayerId' => 'player-2',
+        ], $event->broadcastWith());
+    }
+}

--- a/tests/Unit/Events/PlayerJoinedLobbyTest.php
+++ b/tests/Unit/Events/PlayerJoinedLobbyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\PlayerJoinedLobby;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Tests\TestCase;
+
+class PlayerJoinedLobbyTest extends TestCase
+{
+    public function test_it_implements_should_broadcast(): void
+    {
+        $event = new PlayerJoinedLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertInstanceOf(ShouldBroadcast::class, $event);
+    }
+
+    public function test_it_broadcasts_on_lobby_presence_channel(): void
+    {
+        $event = new PlayerJoinedLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(PresenceChannel::class, $channel);
+        $this->assertSame('presence-lobby.tic-tac-toe', $channel->name);
+    }
+
+    public function test_it_broadcasts_as_player_joined_lobby(): void
+    {
+        $event = new PlayerJoinedLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertSame('player.joined.lobby', $event->broadcastAs());
+    }
+
+    public function test_it_broadcasts_correct_payload(): void
+    {
+        $event = new PlayerJoinedLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertSame([
+            'gameSlug' => 'tic-tac-toe',
+            'player' => [
+                'id' => 'player-1',
+                'name' => 'Alice',
+            ],
+        ], $event->broadcastWith());
+    }
+}

--- a/tests/Unit/Events/PlayerLeftLobbyTest.php
+++ b/tests/Unit/Events/PlayerLeftLobbyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\PlayerLeftLobby;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Tests\TestCase;
+
+class PlayerLeftLobbyTest extends TestCase
+{
+    public function test_it_implements_should_broadcast(): void
+    {
+        $event = new PlayerLeftLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertInstanceOf(ShouldBroadcast::class, $event);
+    }
+
+    public function test_it_broadcasts_on_lobby_presence_channel(): void
+    {
+        $event = new PlayerLeftLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(PresenceChannel::class, $channel);
+        $this->assertSame('presence-lobby.tic-tac-toe', $channel->name);
+    }
+
+    public function test_it_broadcasts_as_player_left_lobby(): void
+    {
+        $event = new PlayerLeftLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertSame('player.left.lobby', $event->broadcastAs());
+    }
+
+    public function test_it_broadcasts_correct_payload(): void
+    {
+        $event = new PlayerLeftLobby(
+            gameSlug: 'tic-tac-toe',
+            playerId: 'player-1',
+            playerName: 'Alice',
+        );
+
+        $this->assertSame([
+            'gameSlug' => 'tic-tac-toe',
+            'player' => [
+                'id' => 'player-1',
+                'name' => 'Alice',
+            ],
+        ], $event->broadcastWith());
+    }
+}


### PR DESCRIPTION
Added broadcast events and channel authorization.

### What’s included
- Added events:
  - MoveMade
  - GameStarted
  - GameEnded
  - PlayerJoinedLobby
  - PlayerLeftLobby
  - ChatMessageSent

- Configured channel authorization:
  - `game.{sessionId}` (presence)
  - `lobby.{gameSlug}` (presence)
  - `game.{sessionId}.chat` (private)

### Code review updates
- Moved inline closures from `channels.php` into dedicated classes
- Fixed `broadcastOn()` to return correct channel types (`PrivateChannel` / `PresenceChannel`)
- Added `GameSessionPolicy` to handle authorization logic
- Created testing units