### PR TITLE
Implemented automated production deployment and server configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy to CAX11
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  # Gate the deploy on a green test run. Prod uses SQLite, but we test against
+  # MySQL (same as the PR `tests` workflow) so we don't change the matrix the
+  # suite is known to pass on.
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: testing
+          MYSQL_USER: sail
+          MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: testing
+      DB_USERNAME: sail
+      DB_PASSWORD: password
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, dom, fileinfo, mysql, redis, bcmath
+          coverage: none
+          tools: composer:v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
+      - name: Prepare environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Wait for MySQL
+        run: |
+          until mysqladmin ping -h 127.0.0.1 -u root -ppassword --silent; do
+            echo "Waiting for MySQL..."
+            sleep 2
+          done
+
+      - name: Run migrations
+        run: php artisan migrate --force
+
+      - name: Run tests
+        run: php artisan test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH and run deploy script
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script_stop: true
+          script: /home/deploy/Zvrk/deploy/deploy.sh

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,7 +20,10 @@ return Application::configure(basePath: dirname(__DIR__))
             AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        // Behind nginx (TLS termination) in production: trust the proxy so
+        // Laravel reads X-Forwarded-Proto and treats requests as HTTPS.
+        // Without this, secure session cookies and generated URLs break.
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -1,0 +1,67 @@
+# Production .env template. Fill the blanks (APP_KEY, REVERB_APP_KEY/SECRET)
+# with fresh values; never commit a real one.
+
+APP_NAME=Zvrk
+APP_ENV=production
+APP_KEY=                                   # php artisan key:generate
+APP_DEBUG=false
+APP_URL=https://zvrk.leokocijan.dev
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+APP_MAINTENANCE_DRIVER=file
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_LEVEL=warning
+
+# --- Database: SQLite (the file is created by deploy.sh) ---
+DB_CONNECTION=sqlite
+# DB_DATABASE defaults to database/database.sqlite; leave the mysql vars unset.
+
+# --- Sessions / cache / queue: Redis ---
+SESSION_DRIVER=redis
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=zvrk.leokocijan.dev
+SESSION_SECURE_COOKIE=true
+
+CACHE_STORE=redis
+QUEUE_CONNECTION=redis
+
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+FILESYSTEM_DISK=local
+
+MAIL_MAILER=log
+MAIL_FROM_ADDRESS="hello@zvrk.leokocijan.dev"
+MAIL_FROM_NAME="${APP_NAME}"
+
+# --- Broadcasting / Reverb ---
+BROADCAST_CONNECTION=reverb
+
+REVERB_APP_ID=zvrk
+REVERB_APP_KEY=                            # set me (random)
+REVERB_APP_SECRET=                         # set me (random)
+
+# Where the SERVER (queue worker) publishes events -> Reverb on localhost.
+# Keeps the events API off the public internet.
+REVERB_HOST=127.0.0.1
+REVERB_PORT=8080
+REVERB_SCHEME=http
+
+# Where the Reverb process binds.
+REVERB_SERVER_HOST=0.0.0.0
+REVERB_SERVER_PORT=8080
+
+# Where the BROWSER connects (baked into the JS bundle at `npm run build`).
+VITE_APP_NAME="${APP_NAME}"
+VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+VITE_REVERB_HOST=zvrk.leokocijan.dev
+VITE_REVERB_PORT=443
+VITE_REVERB_SCHEME=https

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Deploy Zvrk. Run by the GitHub Actions workflow (SSH) or manually on the box:
+# pull, build, migrate, rebuild caches, restart the long-lived services.
+set -euo pipefail
+
+APP_DIR=/home/deploy/Zvrk
+# Match this to the box's PHP-FPM unit (`ls /run/php` / `systemctl list-units 'php*-fpm*'`)
+# and to the name allowed in /etc/sudoers.d/zvrk-deploy.
+PHP_FPM_SERVICE=php8.3-fpm
+
+cd "$APP_DIR"
+
+echo "==> Pulling latest main"
+git fetch --prune origin
+git reset --hard origin/main
+
+echo "==> Installing PHP deps (production)"
+composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
+
+echo "==> Building frontend (vite -> public/build)"
+# Note: VITE_REVERB_* are read from .env at build time and baked into the
+# bundle, so .env must hold the production (zvrk.leokocijan.dev) values.
+npm ci
+npm run build
+
+echo "==> Ensuring SQLite database file exists"
+touch database/database.sqlite
+
+echo "==> Running migrations"
+php artisan migrate --force
+
+echo "==> Rebuilding caches"
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+php artisan event:cache
+
+echo "==> Restarting realtime services"
+# A fresh systemd restart picks up the new code for both the worker and Reverb.
+sudo systemctl restart zvrk-queue
+sudo systemctl restart zvrk-reverb
+sudo systemctl reload "$PHP_FPM_SERVICE"
+
+echo "==> Done."
+systemctl --no-pager --lines=0 status zvrk-reverb zvrk-queue || true

--- a/deploy/nginx-zvrk.conf
+++ b/deploy/nginx-zvrk.conf
@@ -1,0 +1,50 @@
+# nginx server block for Zvrk. Only the client WebSocket path (/app) is proxied
+# to Reverb; the Pusher events API stays private (worker publishes via localhost).
+# Match the fastcgi_pass socket to the box's PHP-FPM version (`ls /run/php`).
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name zvrk.leokocijan.dev;
+
+    root /home/deploy/Zvrk/public;
+    index index.php;
+
+    charset utf-8;
+    client_max_body_size 12M;
+
+    # --- Reverb WebSocket: clients connect to wss://zvrk.leokocijan.dev/app/<key> ---
+    location /app {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # --- Laravel app (served by PHP-FPM) ---
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    location ~ \.php$ {
+        fastcgi_pass unix:/run/php/php8.3-fpm.sock;   # <-- match `ls /run/php`
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+
+    access_log /var/log/nginx/zvrk.access.log;
+    error_log  /var/log/nginx/zvrk.error.log;
+}

--- a/deploy/zvrk-queue.service
+++ b/deploy/zvrk-queue.service
@@ -1,0 +1,21 @@
+# Queue worker. Required for realtime: broadcast events are queued, so without
+# this no game updates reach clients. Also runs ForfeitDisconnectedPlayerJob.
+[Unit]
+Description=Zvrk queue worker (broadcasts + jobs)
+After=network.target redis-server.service
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/Zvrk
+ExecStart=/usr/bin/php artisan queue:work redis --queue=default --sleep=1 --tries=3 --max-time=3600 --max-jobs=1000
+Restart=always
+RestartSec=3
+
+MemoryMax=256M
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/zvrk-reverb.service
+++ b/deploy/zvrk-reverb.service
@@ -1,0 +1,21 @@
+# Reverb WebSocket server. Binds localhost:8080; nginx proxies /app to it.
+[Unit]
+Description=Zvrk Reverb WebSocket server
+After=network.target redis-server.service
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/Zvrk
+ExecStart=/usr/bin/php artisan reverb:start --host=0.0.0.0 --port=8080
+Restart=always
+RestartSec=3
+
+# Bounded so a leak can't starve the shared box.
+MemoryMax=512M
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/zvrk-scheduler.service
+++ b/deploy/zvrk-scheduler.service
@@ -1,0 +1,11 @@
+# One scheduler tick (fired every minute by zvrk-scheduler.timer).
+# Runs game:process-disconnections (see bootstrap/app.php).
+[Unit]
+Description=Zvrk Laravel scheduler (one tick)
+
+[Service]
+Type=oneshot
+User=deploy
+Group=deploy
+WorkingDirectory=/home/deploy/Zvrk
+ExecStart=/usr/bin/php artisan schedule:run

--- a/deploy/zvrk-scheduler.timer
+++ b/deploy/zvrk-scheduler.timer
@@ -1,0 +1,13 @@
+# Fires zvrk-scheduler.service every minute (the cron-less equivalent of
+# `* * * * * php artisan schedule:run`).
+
+[Unit]
+Description=Run Zvrk Laravel scheduler every minute
+
+[Timer]
+OnCalendar=minutely
+AccuracySec=1s
+Persistent=false
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This commit establishes a comprehensive deployment pipeline and server setup for the application (CAX11). It includes:

- A GitHub Actions workflow (`deploy.yml`) for continuous deployment on `main` branch pushes and manual triggers.
- A `deploy.sh` script to pull code, install dependencies, build assets, run migrations, rebuild caches, and restart services (PHP-FPM, queue, Reverb).
- Systemd service units for the Laravel queue worker, Reverb WebSocket server, and scheduler.
- Nginx configuration (`nginx-zvrk.conf`) to serve the application and proxy client WebSocket connections to Reverb.
- A production `.env` template (`.env.production.example`) configuring SQLite, Redis, and Reverb for the production environment.
- Laravel proxy trust configuration in `bootstrap/app.php` to correctly handle HTTPS when behind Nginx.
